### PR TITLE
fix: unified arrays in js file and in json

### DIFF
--- a/autocoplete.test.js
+++ b/autocoplete.test.js
@@ -27,7 +27,7 @@ describe('.createAutoComplete', () => {
 
 describe('.autocomplete', () => {
     it('should always return an array', () => {
-        const autocomplete = createAutoComplete(['a', 'Ab']);
+        const autocomplete = createAutoComplete(['Ab', 'a']);
 
         expect(Array.isArray(autocomplete('sdfasdfas'))).toBe(true);
         expect(Array.isArray(autocomplete(''))).toBe(true);
@@ -42,14 +42,14 @@ describe('.autocomplete', () => {
     });
 
     it('Should be case insensentitive', () => {
-        const autocomplete = createAutoComplete([ 'a', 'Ab']);
+        const autocomplete = createAutoComplete(['Ab', 'a']);
 
-        expect(autocomplete('a')).toEqual(['a', 'Ab']);
-        expect(autocomplete('A')).toEqual(['a', 'Ab']);
+        expect(autocomplete('a')).toEqual(['Ab', 'a']);
+        expect(autocomplete('A')).toEqual(['Ab', 'a']);
     });
 
     it('Should return empty array if input is empty or nothing matches', () => {
-        const autocomplete = createAutoComplete(['a', 'Ab']);
+        const autocomplete = createAutoComplete(['Ab', 'a']);
 
         expect(autocomplete()).toEqual([]);
         expect(autocomplete('')).toEqual([]);


### PR DESCRIPTION
В тестах массивы проверяются не по содержимому, а по индексам(порядок имеет значение). Но вот какую сортировку использовать не очень понятно. Т.к. в тестах на ['a', 'Ab'] используется первая сортировка, а в json файлах уже вторая .  Если же работать с данными в том виде в котором они приходят, то все хорошо. Но если входящие массивы сначала отсортировать, то для разных тестов нужно использовать разные сортировки, чтобы на выходе совпала последовательность.
Данный комит позволяет унифицировать сортировки, применяемые на выходных данных
![question](https://user-images.githubusercontent.com/31983295/68076224-f062cb80-fdc2-11e9-964e-fdd837c365e9.png)
